### PR TITLE
Ignore `NoMissingClientDirectives` rule

### DIFF
--- a/src/generateConfig.ts
+++ b/src/generateConfig.ts
@@ -16,7 +16,12 @@ const DEFAULTS = {
   src: "./src",
 }
 
-const ValidationRulesToExcludeForRelay = ["KnownArgumentNames", "NoUndefinedVariables", "VariablesInAllowedPosition"]
+const ValidationRulesToExcludeForRelay = [
+  "KnownArgumentNames",
+  "NoUndefinedVariables",
+  "VariablesInAllowedPosition",
+  "NoMissingClientDirectives",
+]
 
 function loadRelayConfig() {
   if (!RelayConfig) {


### PR DESCRIPTION
Relay doesn't use the `@client` directive so we should ignore this rule by default.