### PR TITLE
Compat: Validate presence of missing connection directive

### DIFF
--- a/src/RelayCompatMissingConnectionDirective.ts
+++ b/src/RelayCompatMissingConnectionDirective.ts
@@ -1,0 +1,33 @@
+import { ValidationRule, FieldNode } from "graphql"
+import { getConnectionDirective, isConnectionType } from "./utils"
+import { GraphQLError } from "./dependencies"
+
+function hasAfterArgument(fieldNode: FieldNode): boolean {
+  return !!(fieldNode.arguments && fieldNode.arguments.find(arg => arg.name.value === "after"))
+}
+
+function hasBeforeArgument(fieldNode: FieldNode): boolean {
+  return !!(fieldNode.arguments && fieldNode.arguments.find(arg => arg.name.value === "before"))
+}
+
+export const RelayCompatMissingConnectionDirective: ValidationRule = function RelayCompatMissingConnectionDirective(
+  context
+) {
+  return {
+    Field: {
+      enter(fieldNode) {
+        if (!fieldNode.selectionSet) {
+          return
+        }
+        const type = context.getType()
+        if (!type || !isConnectionType(type)) {
+          return
+        }
+        const connectionDirective = getConnectionDirective(fieldNode)
+        if (!connectionDirective && (hasAfterArgument(fieldNode) || hasBeforeArgument(fieldNode))) {
+          context.reportError(new GraphQLError("Missing @connection directive", fieldNode))
+        }
+      },
+    },
+  }
+}

--- a/src/RelayCompatRequiredPageInfoFields.ts
+++ b/src/RelayCompatRequiredPageInfoFields.ts
@@ -1,43 +1,6 @@
-import {
-  ValidationRule,
-  GraphQLOutputType,
-  FieldNode,
-  SelectionSetNode,
-  FragmentDefinitionNode,
-  DirectiveNode,
-} from "graphql"
-import { getNullableType, GraphQLObjectType, GraphQLError, visit } from "./dependencies"
-
-function isConnectionType(type: GraphQLOutputType): boolean {
-  const nullableType = getNullableType(type)
-
-  if (!(nullableType instanceof GraphQLObjectType)) {
-    return false
-  }
-
-  return nullableType.name.endsWith("Connection")
-}
-
-function getConnectionDirective(fieldNode: FieldNode): { key: string | null; directive: DirectiveNode } | null {
-  const directive = fieldNode.directives && fieldNode.directives.find(d => d.name.value === "connection")
-
-  if (!directive) {
-    return null
-  }
-
-  const keyArgument = directive.arguments && directive.arguments.find(arg => arg.name.value === "key")
-  if (!keyArgument || keyArgument.value.kind !== "StringValue") {
-    return {
-      key: null,
-      directive: directive,
-    }
-  }
-
-  return {
-    key: keyArgument.value.value,
-    directive: directive,
-  }
-}
+import { ValidationRule, FieldNode, SelectionSetNode, FragmentDefinitionNode } from "graphql"
+import { GraphQLError, visit } from "./dependencies"
+import { isConnectionType, getConnectionDirective } from "./utils"
 
 function hasFirstArgument(fieldNode: FieldNode): boolean {
   return !!(fieldNode.arguments && fieldNode.arguments.find(arg => arg.name.value === "first"))

--- a/src/generateConfig.ts
+++ b/src/generateConfig.ts
@@ -10,6 +10,7 @@ import { RelayVariablesInAllowedPosition } from "./RelayVariablesInAllowedPositi
 import { RelayArgumentsOfCorrectType } from "./RelayArgumentsOfCorrectType"
 import { RelayDefaultValueOfCorrectType } from "./RelayDefaultValueOfCorrectType"
 import { RelayCompatRequiredPageInfoFields } from "./RelayCompatRequiredPageInfoFields"
+import { RelayCompatMissingConnectionDirective } from "./RelayCompatMissingConnectionDirective"
 
 const DEFAULTS = {
   localSchemaFile: "./data/schema.graphql",
@@ -49,7 +50,7 @@ export function generateConfig(compat: boolean = false) {
   const relayConfig = loadRelayConfig()
   const extensions = getInputExtensions(relayConfig)
   const directivesFile = generateDirectivesFile()
-  const compatOnlyRules = compat ? [RelayCompatRequiredPageInfoFields] : []
+  const compatOnlyRules = compat ? [RelayCompatRequiredPageInfoFields, RelayCompatMissingConnectionDirective] : []
 
   const includesGlobPattern = (inputExtensions: string[]) => `**/*.{graphql,${inputExtensions.join(",")}}`
 

--- a/tests/RelayCompatMissingConnectionDirective-test.ts
+++ b/tests/RelayCompatMissingConnectionDirective-test.ts
@@ -1,0 +1,101 @@
+import { RelayCompatMissingConnectionDirective } from "../src/RelayCompatMissingConnectionDirective"
+import { parse, buildSchema, validate } from "graphql"
+import { generateDirectivesFile } from "../src/generateDirectivesFile"
+import { readFileSync } from "fs"
+
+const schema = buildSchema(`
+${readFileSync(generateDirectivesFile(), "utf8")}
+
+type Foo {
+  bar: String
+  baz: Boolean
+}
+
+type FooEdge {
+    node: Foo
+    cursor: String!
+}
+
+type FooConnection {
+    edges: [FooEdge!]!
+    pageInfo: PageInfo!
+}
+
+type PageInfo {
+    hasPreviousPage: Boolean!
+    hasNextPage: Boolean!
+    endCursor: String
+    startCursor: String
+}
+
+type Query {
+	fooConnection(first: Int last: Int after: String before: String): FooConnection
+	foo: Foo
+}
+`)
+
+function validateDocuments(source: string) {
+  return validate(schema, parse(source), [RelayCompatMissingConnectionDirective])
+}
+
+describe(RelayCompatMissingConnectionDirective, () => {
+  it("Should allow connections without @connection directive when no before or after is used", () => {
+    const errors = validateDocuments(`
+      query MyQuery {
+        fooConnection {
+          __typename
+        }
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+  it("Should disallow connections without @connection directive when before is used", () => {
+    const errors = validateDocuments(`
+      query MyQuery {
+        fooConnection(before: $before) {
+          __typename
+        }
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        message: "Missing @connection directive",
+      })
+    )
+  })
+  it("Should disallow connections without @connection directive when after is used", () => {
+    const errors = validateDocuments(`
+      query MyQuery {
+        fooConnection(after: $after) {
+          __typename
+        }
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        message: "Missing @connection directive",
+      })
+    )
+  })
+  it("Should allow connections with @connection directive", () => {
+    const errors = validateDocuments(`
+      query MyQuery {
+        fooConnection(before: $before) @connection(key: "MyQuery_fooConnection") {
+          __typename
+        }
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  it("Should allow non connectionfields without @connection directive", () => {
+    const errors = validateDocuments(`
+      query MyQuery {
+        foo
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Not sure if this should be a compat only rule or not. I
believe one at least encounters proper errors for this under
the modern runtime. However when using compat having this rule
will aid us in transitioning to modern by being able to
use a compat component under modern runtime with higher confidence.
Compat components can paginate without @connection directive under
classic runtime, so this should help some.