### PR TITLE
support __clientField directive

### DIFF
--- a/src/generateDirectivesFile.ts
+++ b/src/generateDirectivesFile.ts
@@ -14,6 +14,7 @@ export function generateDirectivesFile() {
     ...IRTransforms.schemaExtensions,
     "directive @arguments on FRAGMENT_SPREAD",
     "directive @argumentDefinitions on FRAGMENT_DEFINITION",
+    "directive @__clientField(handle: String!) on FIELD"
   ]
   fs.writeFileSync(tempfile, extensions.join("\n"))
   return tempfile


### PR DESCRIPTION
Thank you so much for this repo! relay support was the only thing keeping me tied to webstorm.

this adds support for the `__clientField` directive. 