### PR TITLE
Fix rule name lookup

### DIFF
--- a/src/RelayKnownArgumentNames.ts
+++ b/src/RelayKnownArgumentNames.ts
@@ -11,7 +11,7 @@ import { defaultValidationRules, didYouMean, GraphQLError, parseType, suggestion
 import { getArgumentDefinitions } from "./argumentDefinitions"
 import { containsVariableNodes } from "./utils"
 
-const KnownArgumentNames = defaultValidationRules.find(rule => rule.name === "KnownArgumentNames")!
+const KnownArgumentNames = defaultValidationRules.find(rule => rule.name === "KnownArgumentNamesRule")!
 
 export const RelayKnownArgumentNames: ValidationRule = function RelayKnownArgumentNames(context) {
   const originalRuleVisitor = KnownArgumentNames(context)


### PR DESCRIPTION
Noticed that VSCode started throwing an error (though the plugin still works?) due to an invalid rule name reference:

```
(node:63943) UnhandledPromiseRejectionWarning: TypeError: KnownArgumentNames is not a function
    at RelayKnownArgumentNames (/Users/willdoenlen/code/force/node_modules/vscode-apollo-relay/dist/RelayKnownArgumentNames.js:15:31)
```

