### PR TITLE
Fix link to relay-config documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ yarn run test
 MIT © [Eloy Durán](https://github.com/alloy)
 
 [vscode-apollo]: https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo
-[relay-config]: https://relay.dev/docs/en/installation-and-setup#set-up-relay-with-a-single-config-file
+[relay-config]: https://relay.dev/docs/getting-started/installation-and-setup/#set-up-relay-with-a-single-config-file


### PR DESCRIPTION
Pretty self-explanatory, just fixes the links to the `relay-config` documentation in the README.